### PR TITLE
Libraries update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.6] - 06-06-2023
+
+## Changed
+- Update the following dependencies
+  - maven-surefire-plugin.version>3.1.2
+  - restassured.version>5.3.1
+  - junit.jupiter.version>5.10.0-M1
+  - datafaker.version>2.0.1
+  - allure.version>2.23.0
+  - aspectj.version>1.9.19
+- Added `commons-codec` and `jackson-databind` libraries explicitly to solve dependencies security issues
+- Updated `READM` and `CONTRIBUTION` mentioning Java 17
+
 ## [2.2.5] - 14-03-2023
 
 ## Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Do not forget to add a _label_ on the issue or feature.
 Excellent! Thank you to help me out!
 
 You're going to need a few things first:
-* JDK 11+
+* JDK 17+
 * [Configure your IDE](https://projectlombok.org/setup/overview) in order to support Lombok.
 
 ## Send a pull request

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It tests the API: [combined-credit-api](https://github.com/eliasnogueira/combine
 > but the central point of this repository and demonstrate an example of running tests for API in a pipeline
 
 ## Required software
-* Java JDK 11+
+* Java JDK 17+
 * Maven installed and in your classpath
 * Clone/download the backend API [combined-credit-api](https://github.com/eliasnogueira/combined-credit-api)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,29 +6,33 @@
 
     <groupId>com.eliasogueira.credit</groupId>
     <artifactId>restassured-complete-basic-example</artifactId>
-    <version>2.2.5-SNAPSHOT</version>
+    <version>2.2.6-SNAPSHOT</version>
 
     <properties>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
 
-        <restassured.version>5.3.0</restassured.version>
-        <junit.jupiter.version>5.9.2</junit.jupiter.version>
+        <restassured.version>5.3.1</restassured.version>
+        <junit.jupiter.version>5.10.0-M1</junit.jupiter.version>
         <assertj.version>3.24.2</assertj.version>
-        <datafaker.version>1.8.1</datafaker.version>
+        <datafaker.version>2.0.1</datafaker.version>
         <owner.version>1.0.12</owner.version>
         <log4j.version>2.20.0</log4j.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <allure.version>2.21.0</allure.version>
+        <allure.version>2.23.0</allure.version>
         <allure-maven.version>2.12.0</allure-maven.version>
-        <aspectj.version>1.9.9.1</aspectj.version>
+        <aspectj.version>1.9.19</aspectj.version>
         <allure.cmd.download.url>
             https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline
         </allure.cmd.download.url>
+
+        <!-- Security override libraries -->
+        <commons-codec.version>1.16.0</commons-codec.version>
+        <jackson-databind.version>2.15.2</jackson-databind.version>
     </properties>
 
     <dependencies>
@@ -36,12 +40,24 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${restassured.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${restassured.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -115,6 +131,19 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+
+        <!-- Libraries added due to security issues -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Changed
- Update the following dependencies
  - maven-surefire-plugin.version>3.1.2
  - restassured.version>5.3.1
  - junit.jupiter.version>5.10.0-M1
  - datafaker.version>2.0.1
  - allure.version>2.23.0
  - aspectj.version>1.9.19
- Added `commons-codec` and `jackson-databind` libraries explicitly to solve dependencies security issues
- Updated `READM` and `CONTRIBUTION` mentioning Java 17